### PR TITLE
Take scenes out of completed group

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -31,11 +31,11 @@ script = ExtResource("1_mjxak")
 process_mode = 4
 visible = false
 
-[node name="MouseGame" parent="SubViewportContainer/SubViewport/Games" groups=["completed"] instance=ExtResource("3_56twc")]
+[node name="MouseGame" parent="SubViewportContainer/SubViewport/Games" instance=ExtResource("3_56twc")]
 process_mode = 4
 visible = false
 
-[node name="Platformer2D" parent="SubViewportContainer/SubViewport/Games" groups=["completed"] instance=ExtResource("4_gp84m")]
+[node name="Platformer2D" parent="SubViewportContainer/SubViewport/Games" instance=ExtResource("4_gp84m")]
 process_mode = 4
 visible = false
 


### PR DESCRIPTION
Hey! I saw that in the ludum dare version it shows 2/3 games completed and it only played the 3d platformer. I take the other games out of the "completed" group and it worked, and it felt quite good actually (although the screen shake moved your mouse, and after some time the progress bar for 10 seconds would desync)